### PR TITLE
Ensure pure-Python parser even if already loaded

### DIFF
--- a/hagadias/gameroot.py
+++ b/hagadias/gameroot.py
@@ -1,16 +1,12 @@
 """Functionality for loading the Qud game data from various game files."""
 
-import sys
 import time
 from pathlib import Path
-# Force Python XML parser:
-sys.modules['_elementtree'] = None
-from xml.etree import ElementTree as ET  # noqa E402
-
-from hagadias.character_codes import read_gamedata  # noqa E402
+from hagadias.xml import ElementTree as ET
+from hagadias.character_codes import read_gamedata
 from hagadias.helpers import get_dll_version_string, repair_invalid_linebreaks, \
-    repair_invalid_chars  # noqa E402
-from hagadias.qudobject_props import QudObjectProps  # noqa E402
+    repair_invalid_chars
+from hagadias.qudobject_props import QudObjectProps
 
 
 class LineNumberingParser(ET.XMLParser):
@@ -32,7 +28,6 @@ class LineNumberingParser(ET.XMLParser):
         element._end_column_number = self.parser.CurrentColumnNumber
         element._end_byte_index = self.parser.CurrentByteIndex
         return element
-
 
 class GameRoot:
     """Gather together the various data sources provided in a Caves of Qud game root.

--- a/hagadias/gameroot.py
+++ b/hagadias/gameroot.py
@@ -29,6 +29,7 @@ class LineNumberingParser(ET.XMLParser):
         element._end_byte_index = self.parser.CurrentByteIndex
         return element
 
+
 class GameRoot:
     """Gather together the various data sources provided in a Caves of Qud game root.
 

--- a/hagadias/qudobject.py
+++ b/hagadias/qudobject.py
@@ -1,6 +1,5 @@
 """attr specification:
 QudObject.part_name_attribute"""
-import sys
 from copy import deepcopy
 from typing import Tuple, Union, List
 from hagadias.xml import Element

--- a/hagadias/qudobject.py
+++ b/hagadias/qudobject.py
@@ -3,16 +3,11 @@ QudObject.part_name_attribute"""
 import sys
 from copy import deepcopy
 from typing import Tuple, Union, List
-
-# Force Python XML parser:
-sys.modules['_elementtree'] = None
-from xml.etree.ElementTree import Element  # noqa E402
-
-from anytree import NodeMixin  # noqa E402
-
-from hagadias.qudtile import QudTile  # noqa E402
-from hagadias.tilepainter import TilePainter  # noqa E402
-from hagadias.tileanimator import TileAnimator, StandInTiles  # noqa E402
+from hagadias.xml import Element
+from anytree import NodeMixin
+from hagadias.qudtile import QudTile
+from hagadias.tilepainter import TilePainter
+from hagadias.tileanimator import TileAnimator, StandInTiles
 
 
 class QudObject(NodeMixin):

--- a/hagadias/xml.py
+++ b/hagadias/xml.py
@@ -1,0 +1,12 @@
+import sys
+# Force pure Python XML parser by nullifying the import
+# in ElementTree that would normally shadow XMLParser with
+# the C version. This lets us get line number info.
+sys.modules['_elementtree'] = None
+already_imported = 'xml.etree' in sys.modules
+from xml.etree import ElementTree  # noqa E402
+from xml.etree.ElementTree import Element  # noqa E402
+if already_imported:
+    import importlib  # noqa E402
+    importlib.reload(ElementTree)
+

--- a/hagadias/xml.py
+++ b/hagadias/xml.py
@@ -5,7 +5,7 @@ import sys
 sys.modules['_elementtree'] = None
 already_imported = 'xml.etree' in sys.modules
 from xml.etree import ElementTree  # noqa E402
-from xml.etree.ElementTree import Element  # noqa E402
 if already_imported:
     import importlib  # noqa E402
     importlib.reload(ElementTree)
+from xml.etree.ElementTree import Element  # noqa E402

--- a/hagadias/xml.py
+++ b/hagadias/xml.py
@@ -9,4 +9,3 @@ from xml.etree.ElementTree import Element  # noqa E402
 if already_imported:
     import importlib  # noqa E402
     importlib.reload(ElementTree)
-


### PR DESCRIPTION
This method ensures that the pure Python version of the XML parser gets loaded even if the C extension was already imported previously. Fixes error I encountered in running pytest from command line on Windows