### PR TITLE
Fix role determinations for creatures

### DIFF
--- a/hagadias/qudobject_props.py
+++ b/hagadias/qudobject_props.py
@@ -2215,7 +2215,7 @@ class QudObjectProps(QudObject):
         Example: Programmable Recoiler has "Uncommon"
         Albino ape has "Brute"
         """
-        return self.property_Role_Value
+        return self.tag_Role_Value
 
     @cached_property
     def savemodifier(self) -> str | None:

--- a/hagadias/tileanimator.py
+++ b/hagadias/tileanimator.py
@@ -23,8 +23,13 @@ POWER_TRANSMISSION_PARTS = [
     "HydraulicPowerTransmission",
     "MechanicalPowerTransmission",
 ]
-ANIMATEDMATERIALGENERIC_EXCLUSIONS = ["Telescope", "Full-Scale Recompositer", "PistonPressElement",
-                                      "Chavvah Dense Leaves", "Chavvah Sparse Leaves"]
+ANIMATEDMATERIALGENERIC_EXCLUSIONS = [
+    "Telescope",
+    "Full-Scale Recompositer",
+    "PistonPressElement",
+    "Chavvah Dense Leaves",
+    "Chavvah Sparse Leaves",
+]
 
 
 class TileAnimator:


### PR DESCRIPTION
Roles are now specified as tags on a creature rather than (string) properties.