### PR TITLE
Fix anatomy processing and failing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,7 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+# VSCode
+.vscode
+
 game_location_for_tests

--- a/hagadias/constants.py
+++ b/hagadias/constants.py
@@ -219,7 +219,7 @@ QUD_COLORS = {
     "o": (241, 95, 34),
     "O": (233, 159, 16),
     "transparent": (15, 59, 58, 0),
-    "#": (15, 59, 58, 0), # HACK HACK HACK
+    "#": (15, 59, 58, 0),  # HACK HACK HACK
 }
 QUD_VIRIDIAN = (15, 59, 58, 255)  # 0f3b3a
 LIQUID_COLORS = {

--- a/hagadias/gameroot.py
+++ b/hagadias/gameroot.py
@@ -161,6 +161,8 @@ class GameRoot:
         tag_anatomies = tree.find("anatomies")
         for tag_anatomy in tag_anatomies:
             parts = []
+            if isinstance(tag_anatomy, et._Comment):
+                continue
             name = tag_anatomy.attrib["Name"]
             # .// XPath syntax means select all <part> tags under this element, even if nested
             found_tag_part = tag_anatomy.findall(".//part")

--- a/hagadias/gameroot.py
+++ b/hagadias/gameroot.py
@@ -93,7 +93,7 @@ class GameRoot:
             log.debug("Repairing invalid XML line breaks... ")
             contents = repair_invalid_linebreaks(contents)
             log.debug("done in %.2f seconds", time.time() - start)
-            raw = et.fromstring(bytes(contents, encoding='utf-8'))
+            raw = et.fromstring(bytes(contents, encoding="utf-8"))
             # Objects must receive the qindex and add themselves, rather than doing it here, because
             # they need access to their parent by name lookup during creation for inheritance
             # calculations.

--- a/tests/qudobject_props_test.py
+++ b/tests/qudobject_props_test.py
@@ -18,11 +18,11 @@ def test_av(qindex):
 
 def test_chargeused(qindex):
     obj = qindex["Geomagnetic Disc"]
-    assert obj.chargeused == 400
+    assert obj.chargeused == 100
 
 
 def test_displayname(qindex):
-    assert qindex["ElderBob"].displayname == "Elder Irudad"
+    assert qindex["ElderBob"].displayname == "Irudad"
     assert qindex["Cudgel6"].displayname == "crysteel mace"
 
 


### PR DESCRIPTION
Hi! I'm castorandpollux on the wiki/discord. I noticed that Irudad has a missing anatomy on the wiki currently. It seems to be due to a comment before the declaration of his anatomy in `Bodies.xml`: `<!-- NPC-specific -->`. This PR checks for comment nodes under `<anatomies>` and skips them.

Also, a few of the tests weren't passing, so I took the liberty of fixing them:
- `test_chargeused`: geomagnetic disk now uses 100 charge instead of 400.
- `test_displayname`: Irudad's title of 'Elder' is now stored in an 'Honorifics' part that currently isn't parsed by hagadias, and which is [manually overridden](https://github.com/TrashMonks/qud-wiki/blob/5971817f1c8ffc140bac74e96cbc24ef65f7a436/config.yml#L571) in qud-wiki. This change gets the test passing but I recognise it's not quite in the spirit of the test... happy to change this one.