### PR TITLE
 Add handling for epithets and honorifics

### DIFF
--- a/hagadias/constants.py
+++ b/hagadias/constants.py
@@ -219,7 +219,7 @@ QUD_COLORS = {
     "o": (241, 95, 34),
     "O": (233, 159, 16),
     "transparent": (15, 59, 58, 0),
-    "#": (15, 59, 58, 0), # HACK HACK HACK
+    "#": (15, 59, 58, 0),  # HACK HACK HACK
 }
 QUD_VIRIDIAN = (15, 59, 58, 255)  # 0f3b3a
 LIQUID_COLORS = {

--- a/hagadias/gameroot.py
+++ b/hagadias/gameroot.py
@@ -93,7 +93,7 @@ class GameRoot:
             log.debug("Repairing invalid XML line breaks... ")
             contents = repair_invalid_linebreaks(contents)
             log.debug("done in %.2f seconds", time.time() - start)
-            raw = et.fromstring(bytes(contents, encoding='utf-8'))
+            raw = et.fromstring(bytes(contents, encoding="utf-8"))
             # Objects must receive the qindex and add themselves, rather than doing it here, because
             # they need access to their parent by name lookup during creation for inheritance
             # calculations.

--- a/hagadias/helpers.py
+++ b/hagadias/helpers.py
@@ -372,22 +372,25 @@ def strip_oldstyle_qud_colors(text: str) -> str:
     """
     return re.sub("&[rRwWcCbBgGmMyYkKoO]", "", text)
 
-def process_honorifics(dname: str, primary: str|None, ordinary: str|None) -> str:
+
+def process_honorifics(dname: str, primary: str | None, ordinary: str | None) -> str:
     for name_title in [primary, ordinary]:
         if name_title is not None:
             dname = f"{name_title} {dname}"
 
     return dname
 
-def process_epithets(dname: str, primary: str|None, ordinary: str|None) -> str:
+
+def process_epithets(dname: str, primary: str | None, ordinary: str | None) -> str:
     if primary is not None:
-        if primary[0] != ',':
+        if primary[0] != ",":
             dname = f"{dname} {primary}"
         else:
             dname = f"{dname}{primary}"
     # Currently no blueprints use the 'ordinary' portion
 
     return dname
+
 
 def extract_color(colorstr: str, prefix_symbol: str) -> str | None:
     """Generic function to extract a color codes and its prefixing symbol."""

--- a/hagadias/helpers.py
+++ b/hagadias/helpers.py
@@ -385,6 +385,7 @@ def process_epithets(dname: str, primary: str|None, ordinary: str|None) -> str:
             dname = f"{dname} {primary}"
         else:
             dname = f"{dname}{primary}"
+    # Currently no blueprints use the 'ordinary' portion
 
     return dname
 

--- a/hagadias/helpers.py
+++ b/hagadias/helpers.py
@@ -372,6 +372,21 @@ def strip_oldstyle_qud_colors(text: str) -> str:
     """
     return re.sub("&[rRwWcCbBgGmMyYkKoO]", "", text)
 
+def process_honorifics(dname: str, primary: str|None, ordinary: str|None) -> str:
+    for name_title in [primary, ordinary]:
+        if name_title is not None:
+            dname = f"{name_title} {dname}"
+
+    return dname
+
+def process_epithets(dname: str, primary: str|None, ordinary: str|None) -> str:
+    if primary is not None:
+        if primary[0] != ',':
+            dname = f"{dname} {primary}"
+        else:
+            dname = f"{dname}{primary}"
+
+    return dname
 
 def extract_color(colorstr: str, prefix_symbol: str) -> str | None:
     """Generic function to extract a color codes and its prefixing symbol."""

--- a/hagadias/qudobject_props.py
+++ b/hagadias/qudobject_props.py
@@ -23,6 +23,8 @@ from hagadias.dicebag import DiceBag
 from hagadias.helpers import (
     cp437_to_unicode,
     int_or_none,
+    process_epithets,
+    process_honorifics,
     strip_oldstyle_qud_colors,
     strip_newstyle_qud_colors,
     pos_or_neg,
@@ -1323,6 +1325,11 @@ class QudObjectProps(QudObject):
                 for name_title in [self.part_Titles_Primary, self.part_Titles_Ordinary]:
                     if name_title is not None:
                         dname = f"{dname}, {name_title}"
+            if self.part_Honorifics is not None:
+                dname = process_honorifics(dname, self.part_Honorifics_Primary, self.part_Honorifics_Ordinary)
+            if self.part_Epithets is not None:
+                dname = process_epithets(dname, self.part_Epithets_Primary, self.part_Epithets_Ordinary)
+            
             dname = strip_oldstyle_qud_colors(dname)
             dname = strip_newstyle_qud_colors(dname)
         return dname

--- a/hagadias/qudobject_props.py
+++ b/hagadias/qudobject_props.py
@@ -1326,10 +1326,14 @@ class QudObjectProps(QudObject):
                     if name_title is not None:
                         dname = f"{dname}, {name_title}"
             if self.part_Honorifics is not None:
-                dname = process_honorifics(dname, self.part_Honorifics_Primary, self.part_Honorifics_Ordinary)
+                dname = process_honorifics(
+                    dname, self.part_Honorifics_Primary, self.part_Honorifics_Ordinary
+                )
             if self.part_Epithets is not None:
-                dname = process_epithets(dname, self.part_Epithets_Primary, self.part_Epithets_Ordinary)
-            
+                dname = process_epithets(
+                    dname, self.part_Epithets_Primary, self.part_Epithets_Ordinary
+                )
+
             dname = strip_oldstyle_qud_colors(dname)
             dname = strip_newstyle_qud_colors(dname)
         return dname

--- a/tests/qudobject_props_test.py
+++ b/tests/qudobject_props_test.py
@@ -22,7 +22,46 @@ def test_chargeused(qindex):
 
 
 def test_displayname(qindex):
-    assert qindex["ElderBob"].displayname == "Elder Irudad"
+    testcases = {
+        "Tam": "Tam, dromad merchant",
+        "High Priest Eschelstadt": "Eschelstadt II, High Priest of the Stilt",
+        "Lulihart": "Lulihart, hindren pariah",
+        "Tszappur": "Tszappur, disciple of the Coiled Lamb",
+        "Oboroqoru": "Oboroqoru, Ape God",
+        "Skybear": "Saad Amus, the Sky-Bear",
+        "Phinae Hoshaiah": "Phinae Hoshaiah, High Priest of the Rock",
+        "Asphodel": "Asphodel, Earl of Omonporch",
+        "Hamilcrab": "Hamilcrab, cyclopean merchant",
+        "AoygNoLonger": "Aoyg-No-Longer, servant of Ptoh in the Cosmic Wood",
+        "Troll King 1": "Jotun, Who Parts Limbs",
+        "Troll King 2": "Fjorn-Kosef, Who Knits The Icy Lattice",
+        "Troll King 3": "Haggabah, Who Plies The Umbral Path",
+        "ElderBob": "Elder Irudad",
+        "Warden Esthers": "Wardens Esther",
+        "Barathrum": "Barathrum the Old",
+        "Neelahind": "Warden Neelahind",
+        "Mayor Nuntu": "Mayor Nuntu",
+        "Warden Indrix": "Warden Indrix, Goatfolk Pariah",
+        "GolgothaSlog": "Slog of the Cloaca",
+        "Haddas": "Mayor Haddas",
+        "Warden 1-FF": "Warden 1-FF, reprogrammed conservator",
+        "Zothom": "Zothom the Penitent",
+        "Rainwater Shomer": "Rainwater Shomer",
+        "Une": "Warden Une",
+        "Agolgot": "Girsh Agolgot",
+        "Bethsaida": "Girsh Bethsaida",
+        "Rermadon": "Girsh Rermadon",
+        "Qas": "Girsh Qas",
+        "Qon": "Girsh Qon",
+        "Shugruith": "Girsh Shug'ruith the Burrower",
+        "Erah": "Ciderer Erah",
+        "Warden Yrame": "Warden Yrame",
+        "Ehalcodon": "Starformed Ehalcodon"
+    }
+
+    for id, expected in testcases.items():
+        assert qindex[id].displayname == expected
+    
     assert qindex["Cudgel6"].displayname == "crysteel mace"
 
 

--- a/tests/qudobject_props_test.py
+++ b/tests/qudobject_props_test.py
@@ -56,12 +56,12 @@ def test_displayname(qindex):
         "Shugruith": "Girsh Shug'ruith the Burrower",
         "Erah": "Ciderer Erah",
         "Warden Yrame": "Warden Yrame",
-        "Ehalcodon": "Starformed Ehalcodon"
+        "Ehalcodon": "Starformed Ehalcodon",
     }
 
     for id, expected in testcases.items():
         assert qindex[id].displayname == expected
-    
+
     assert qindex["Cudgel6"].displayname == "crysteel mace"
 
 


### PR DESCRIPTION
This PR adds handling in `displayname` for `Epithets` and `Honorifics` parts. It's obviously a simplification compared to the real implementation, but works for all the cases in the test. The corpus of name-ID pairs in the test is drawn from the list of display name overrides from [qud-wiki](https://github.com/TrashMonks/qud-wiki/blob/5971817f1c8ffc140bac74e96cbc24ef65f7a436/config.yml#L643-L678).