### PR TITLE
Attach source files to blueprints

### DIFF
--- a/hagadias/gameroot.py
+++ b/hagadias/gameroot.py
@@ -102,7 +102,7 @@ class GameRoot:
             for element in raw:
                 if element.tag != "object":
                     continue
-                cls(element, qindex, self)
+                cls(blueprint_file, element, qindex, self)
 
         # second pass - resolve object inheritance
         log.debug("Resolving Qud object hierarchy and adding tiles...")

--- a/hagadias/qudobject.py
+++ b/hagadias/qudobject.py
@@ -44,7 +44,7 @@ class QudObject(NodeMixin):
     by the AnyTree module that provides NodeMixin.
     """
 
-    def __init__(self, blueprint: etree.Element, qindex: dict, gameroot):
+    def __init__(self, source_file: str, blueprint: etree.Element, qindex: dict, gameroot):
         """Create a new QudObject instance.
 
         Parameters:
@@ -52,6 +52,7 @@ class QudObject(NodeMixin):
             qindex: a dict in which to register this object after creation, keyed by object name
             gameroot: a reference to the GameRoot instance that spawned this object
         """
+        self.source_file = source_file
         self.gameroot = gameroot
         self.source = etree.tostring(blueprint).decode("utf8")
         self.qindex = qindex

--- a/hagadias/qudobject_props.py
+++ b/hagadias/qudobject_props.py
@@ -364,7 +364,9 @@ class QudObjectProps(QudObject):
                     if name[0] in "*#@":
                         # special values like '*Junk 1'
                         continue
-                    item = self.qindex[name]
+                    if (item := self.qindex.get(name)) is None:
+                        log.error("unknown inventory blueprint %s", name)
+                        continue
                     if item.av and (not applied_body_av or item.wornon != "Body"):
                         av += int(item.av)
         return int_or_none(av)
@@ -1382,7 +1384,8 @@ class QudObjectProps(QudObject):
                         if name[0] in "*#@":
                             # special values like '*Junk 1'
                             continue
-                        item = self.qindex[name]
+                        if (item := self.qindex.get(name)) is None:
+                            log.error("unknown inventory blueprint %s", name)
                         if item.dv and (not applied_body_dv or item.wornon != "Body"):
                             dv += item.dv
         return int_or_none(dv)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hagadias"
-version = "1.2.1"
+version = "1.3.0"
 description = "Extract game data from the Caves of Qud roguelike"
 authors = [
     "syntaxaire <syntaxaire@gmail.com>",


### PR DESCRIPTION
This PR makes some small changes to how `QudObject`s are constructed to ensure that the file that they come from is attached to the object. This is useful for determining when an object comes from a special file, e.g. `HiddenObjects.xml`.